### PR TITLE
Tested on UE65KS7000

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Build requirements
 Tested on
 -----
 - Samsung UE50JU6400
+- Samsung UE65KS7000
 - Android - BubbleUPnP app
 
 Author


### PR DESCRIPTION
Tested on Samsung UE65KS7000.
Did go v1.16 remove io/ioutil?