### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ appimage: build
 
 	# Fetch appimagetool if missing
 	if [ ! -x $(APPIMAGETOOL) ]; then \
-		URL="https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-$(ARCH).AppImage"; \
+		URL="https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-$(ARCH).AppImage"; \
 		curl -L "$$URL" -o $(APPIMAGETOOL) || wget -O $(APPIMAGETOOL) "$$URL"; \
 		chmod +x $(APPIMAGETOOL); \
 	fi


### PR DESCRIPTION
Previous appimagetool may be show this error in modern systems like Fedora 42/43, Ubuntu 22.02 and others

dlopen(): error loading libfuse.so.2

`AppImages require FUSE to run. 
You might still be able to extract the contents of this AppImage  if you run it with the --appimage-extract option.  See https://github.com/AppImage/AppImageKit/wiki/FUSE  for more information`

You can use this updated appimagetool which does not reproduce the same error.